### PR TITLE
Add i18n language switcher (NO / EN / ES)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
         "@equinor/eds-core-react": "^2.3.7",
         "@equinor/eds-icons": "^1.3.0",
         "@equinor/eds-tokens": "^2.2.0",
+        "i18next": "^25.8.17",
         "leaflet": "^1.9.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-i18next": "^16.5.7",
         "react-leaflet": "^5.0.0",
         "styled-components": "^6.1.0"
       },
@@ -6328,6 +6330,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.8.17",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.17.tgz",
+      "integrity": "sha512-vWtCttyn5bpOK4hWbRAe1ZXkA+Yzcn2OcACT+WJavtfGMcxzkfvXTLMeOU8MUhRmAySKjU4VVuKlo0sSGeBokA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -7325,6 +7367,33 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "16.5.7",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.7.tgz",
+      "integrity": "sha512-t/si6ng+hMPvgRGNgGvHAkMuVRBsIBx5mN+exm/yiBPSFL7VooQ37YYfISxSE0LjvQjG+MTe+0htKdOJY0S/vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.6.2",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -8282,7 +8351,7 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8562,6 +8631,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "@equinor/eds-core-react": "^2.3.7",
     "@equinor/eds-icons": "^1.3.0",
     "@equinor/eds-tokens": "^2.2.0",
+    "i18next": "^25.8.17",
     "leaflet": "^1.9.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-i18next": "^16.5.7",
     "react-leaflet": "^5.0.0",
     "styled-components": "^6.1.0"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -83,6 +83,37 @@ body {
   letter-spacing: -0.01em;
 }
 
+/* ── Language switcher ── */
+.lang-switcher {
+  display: flex;
+  gap: 2px;
+  margin-left: auto;
+}
+
+.lang-btn {
+  padding: 2px 6px;
+  font-size: 11px;
+  font-weight: 700;
+  font-family: Equinor, sans-serif;
+  border: 1.5px solid #c0c0c0;
+  border-radius: 4px;
+  background: transparent;
+  color: #565656;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.lang-btn:hover:not(.active) {
+  border-color: var(--eds-primary);
+  color: var(--eds-primary);
+}
+
+.lang-btn.active {
+  background: var(--eds-primary);
+  border-color: var(--eds-primary);
+  color: #ffffff;
+}
+
 /* ── Layer toggles ── */
 .layer-toggles {
   display: flex;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Map } from './components/Map'
 import { Sidebar } from './components/Sidebar'
 import { useParking } from './hooks/useParking'
@@ -10,6 +11,7 @@ import './App.css'
 const DEFAULT_INTERVAL = 60_000
 
 export default function App() {
+  const { t } = useTranslation()
   const [refreshInterval, setRefreshInterval] = useState(DEFAULT_INTERVAL)
   const [selectedSpot, setSelectedSpot] = useState<ParkingSpot | null>(null)
   const [selectedStation, setSelectedStation] = useState<BikeStation | null>(null)
@@ -32,14 +34,14 @@ export default function App() {
             <line x1="12" y1="8" x2="12" y2="12" />
             <line x1="12" y1="16" x2="12.01" y2="16" />
           </svg>
-          Kunne ikke laste data. Prøv igjen senere.
+          {t('error.load')}
         </div>
       )}
 
       {(parking.loading && parking.data.length === 0 && bikes.loading && bikes.data.length === 0) && (
         <div className="loading-overlay">
           <div className="spinner" />
-          <span>Laster data…</span>
+          <span>{t('loading')}</span>
         </div>
       )}
 

--- a/src/components/BikeMarker.tsx
+++ b/src/components/BikeMarker.tsx
@@ -1,5 +1,6 @@
 import { divIcon } from 'leaflet'
 import { Marker, Popup } from 'react-leaflet'
+import { useTranslation } from 'react-i18next'
 import type { BikeStation } from '../types/bike'
 
 export function getBikeColor(station: BikeStation): string {
@@ -45,6 +46,7 @@ interface BikeMarkerProps {
 }
 
 export function BikeMarker({ station, isSelected, dimmed, onClick }: BikeMarkerProps) {
+  const { t } = useTranslation()
   const color = getBikeColor(station)
   const textColor = getTextColor(station)
   const size = isSelected ? 52 : dimmed ? 34 : 44
@@ -92,27 +94,27 @@ export function BikeMarker({ station, isSelected, dimmed, onClick }: BikeMarkerP
 
           <div style={{ display: 'flex', gap: '12px', marginBottom: '6px' }}>
             <div>
-              <div style={{ fontSize: '11px', color: '#6f6f6f' }}>Ledige sykler</div>
+              <div style={{ fontSize: '11px', color: '#6f6f6f' }}>{t('bike.available')}</div>
               <div style={{ fontSize: '18px', fontWeight: 700, color }}>{station.num_vehicles_available}</div>
             </div>
             <div>
-              <div style={{ fontSize: '11px', color: '#6f6f6f' }}>Ledige låser</div>
+              <div style={{ fontSize: '11px', color: '#6f6f6f' }}>{t('bike.docks')}</div>
               <div style={{ fontSize: '18px', fontWeight: 700, color: '#3d3d3d' }}>{station.num_docks_available}</div>
             </div>
             <div>
-              <div style={{ fontSize: '11px', color: '#6f6f6f' }}>Kapasitet</div>
+              <div style={{ fontSize: '11px', color: '#6f6f6f' }}>{t('bike.capacity')}</div>
               <div style={{ fontSize: '18px', fontWeight: 700, color: '#3d3d3d' }}>{station.capacity}</div>
             </div>
           </div>
 
           {!station.is_renting && (
             <div style={{ fontSize: '12px', color: '#9ca3af', fontStyle: 'italic', marginBottom: '4px' }}>
-              Stasjonen er ikke aktiv
+              {t('bike.inactive')}
             </div>
           )}
 
           <div style={{ fontSize: '11px', color: '#6f6f6f' }}>
-            Oppdatert: {formatLastReported(station.last_reported)}
+            {t('bike.updated')} {formatLastReported(station.last_reported)}
           </div>
         </div>
       </Popup>

--- a/src/components/ParkingMarker.tsx
+++ b/src/components/ParkingMarker.tsx
@@ -1,5 +1,6 @@
 import { divIcon } from 'leaflet'
 import { Marker, Popup } from 'react-leaflet'
+import { useTranslation } from 'react-i18next'
 import type { ParkingSpot } from '../types/parking'
 
 export function getColor(freeSpots: number): string {
@@ -21,6 +22,7 @@ interface ParkingMarkerProps {
 }
 
 export function ParkingMarker({ spot, isSelected, dimmed, onClick }: ParkingMarkerProps) {
+  const { t } = useTranslation()
   const lat = parseFloat(spot.Latitude)
   const lng = parseFloat(spot.Longitude)
 
@@ -85,7 +87,7 @@ export function ParkingMarker({ spot, isSelected, dimmed, onClick }: ParkingMark
             <span style={{ fontSize: '16px', fontWeight: 700, color }}>
               {spot.Antall_ledige_plasser}
             </span>
-            <span style={{ fontSize: '13px', color: '#565656' }}>ledige plasser</span>
+            <span style={{ fontSize: '13px', color: '#565656' }}>{t('parking.spots')}</span>
           </div>
           <div style={{ fontSize: '12px', color: '#6f6f6f', marginTop: '6px' }}>
             {spot.Dato} kl. {spot.Klokkeslett}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+import i18n from '../i18n'
 import type { ParkingSpot } from '../types/parking'
 import type { BikeStation } from '../types/bike'
 import { getColor } from './ParkingMarker'
@@ -38,6 +40,8 @@ const INTERVAL_OPTIONS = [
   { label: '5 min', value: 300_000 },
 ]
 
+const LANGUAGES = ['no', 'en', 'es'] as const
+
 function formatTime(date: Date): string {
   return date.toLocaleTimeString('no-NO', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 }
@@ -51,6 +55,7 @@ export function Sidebar({
   showParking, onToggleParking,
   showBikes, onToggleBikes,
 }: SidebarProps) {
+  const { t, i18n: i18nInstance } = useTranslation()
   const isParking = activeTab === 'parking'
   const loading = isParking ? parkingLoading : bikeLoading
   const lastUpdated = isParking ? parkingLastUpdated : bikeLastUpdated
@@ -72,7 +77,20 @@ export function Sidebar({
             <circle cx="12" cy="12" r="10" />
             <path d="M8 12h8M12 8v8" />
           </svg>
-          <span>Stavanger mobilitet</span>
+          <span>{t('header.title')}</span>
+
+          {/* Language switcher */}
+          <div className="lang-switcher">
+            {LANGUAGES.map((lng) => (
+              <button
+                key={lng}
+                className={`lang-btn ${i18nInstance.language === lng ? 'active' : ''}`}
+                onClick={() => i18n.changeLanguage(lng)}
+              >
+                {lng.toUpperCase()}
+              </button>
+            ))}
+          </div>
         </div>
 
         {/* Layer toggles */}
@@ -80,18 +98,18 @@ export function Sidebar({
           <button
             className={`layer-toggle ${showParking ? 'active' : ''}`}
             onClick={onToggleParking}
-            title="Vis/skjul parkering"
+            title={t('parking.toggle')}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
               <rect x="3" y="3" width="18" height="18" rx="2"/>
               <path d="M9 17V7h4a3 3 0 0 1 0 6H9"/>
             </svg>
-            Parkering
+            {t('parking.label')}
           </button>
           <button
             className={`layer-toggle ${showBikes ? 'active' : ''}`}
             onClick={onToggleBikes}
-            title="Vis/skjul bysykler"
+            title={t('bikes.toggle')}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <circle cx="5.5" cy="17.5" r="3.5"/>
@@ -99,7 +117,7 @@ export function Sidebar({
               <path d="M15 6a1 1 0 0 0-1 1v5.5H9L5.5 17.5"/>
               <path d="m8 6 1.5 5.5M15 6H8"/>
             </svg>
-            Bysykkel
+            {t('bikes.label')}
           </button>
         </div>
 
@@ -109,14 +127,14 @@ export function Sidebar({
             className={`tab ${isParking ? 'active' : ''}`}
             onClick={() => { onTabChange('parking'); onSearchChange('') }}
           >
-            Parkering
+            {t('tab.parking')}
             <span className="tab-badge">{spots.length}</span>
           </button>
           <button
             className={`tab ${!isParking ? 'active' : ''}`}
             onClick={() => { onTabChange('bikes'); onSearchChange('') }}
           >
-            Bysykkel
+            {t('tab.bikes')}
             <span className="tab-badge">{bikeStations.length}</span>
           </button>
         </div>
@@ -130,20 +148,20 @@ export function Sidebar({
           <input
             type="search"
             className="search-input"
-            placeholder={isParking ? 'Søk etter parkeringsplass…' : 'Søk etter sykkelpunkt…'}
+            placeholder={isParking ? t('search.parking') : t('search.bikes')}
             value={searchQuery}
             onChange={(e) => onSearchChange(e.target.value)}
-            aria-label="Søk"
+            aria-label={t('search.label')}
           />
           {searchQuery && (
-            <button className="search-clear" onClick={() => onSearchChange('')} aria-label="Tøm søk">×</button>
+            <button className="search-clear" onClick={() => onSearchChange('')} aria-label={t('search.clear')}>×</button>
           )}
         </div>
 
         {/* Controls */}
         <div className="sidebar-controls">
           <div className="control-group">
-            <label htmlFor="interval-select" className="control-label">Oppdater</label>
+            <label htmlFor="interval-select" className="control-label">{t('refresh.label')}</label>
             <select
               id="interval-select"
               className="interval-select"
@@ -159,7 +177,7 @@ export function Sidebar({
             className={`refresh-btn ${loading ? 'loading' : ''}`}
             onClick={onRefresh}
             disabled={loading}
-            title="Oppdater nå"
+            title={t('refresh.now')}
           >
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className={loading ? 'spin' : ''}>
               <path d="M23 4v6h-6" />
@@ -170,7 +188,7 @@ export function Sidebar({
         </div>
 
         {lastUpdated && (
-          <div className="last-updated">Sist oppdatert: {formatTime(lastUpdated)}</div>
+          <div className="last-updated">{t('lastUpdated')} {formatTime(lastUpdated)}</div>
         )}
       </div>
 
@@ -180,7 +198,9 @@ export function Sidebar({
           <>
             {filteredSpots.length === 0 && !loading && (
               <div className="empty-state">
-                {searchQuery ? `Ingen treff på "${searchQuery}"` : 'Ingen parkeringsdata tilgjengelig'}
+                {searchQuery
+                  ? t('empty.parkingSearch', { query: searchQuery })
+                  : t('empty.parking')}
               </div>
             )}
             {filteredSpots.map((spot) => {
@@ -203,7 +223,9 @@ export function Sidebar({
           <>
             {filteredStations.length === 0 && !loading && (
               <div className="empty-state">
-                {searchQuery ? `Ingen treff på "${searchQuery}"` : 'Ingen sykkeldata tilgjengelig'}
+                {searchQuery
+                  ? t('empty.bikesSearch', { query: searchQuery })
+                  : t('empty.bikes')}
               </div>
             )}
             {filteredStations.map((station) => {
@@ -218,7 +240,7 @@ export function Sidebar({
                   <span className="spot-indicator bike-indicator" style={{ background: color }} aria-hidden="true" />
                   <span className="spot-name">{station.name}</span>
                   <div className="bike-counts">
-                    <span className="spot-count" style={{ color }} title="Ledige sykler">
+                    <span className="spot-count" style={{ color }} title={t('bike.available')}>
                       {station.num_vehicles_available}
                     </span>
                   </div>
@@ -230,7 +252,7 @@ export function Sidebar({
       </div>
 
       <div className="sidebar-footer">
-        <span>Data: </span>
+        <span>{t('data.label')} </span>
         <a href="https://opencom.no" target="_blank" rel="noopener noreferrer">opencom.no</a>
       </div>
     </aside>

--- a/src/hooks/useBikes.ts
+++ b/src/hooks/useBikes.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import type { BikeStation } from '../types/bike'
+import i18n from '../i18n'
 
 const API_URL = '/api/bikes'
 
@@ -50,7 +51,7 @@ export function useBikes(intervalMs: number): UseBikesResult {
       setLastUpdated(new Date())
     } catch (err) {
       if ((err as Error).name !== 'AbortError') {
-        setError((err as Error).message || 'Ukjent feil')
+        setError((err as Error).message || i18n.t('error.unknown'))
       }
     } finally {
       setLoading(false)

--- a/src/hooks/useParking.ts
+++ b/src/hooks/useParking.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import type { ParkingSpot } from '../types/parking'
+import i18n from '../i18n'
 
 const API_URL = '/api/parking'
 
@@ -55,7 +56,7 @@ export function useParking(intervalMs: number): UseParkingResult {
       setLastUpdated(new Date())
     } catch (err) {
       if ((err as Error).name !== 'AbortError') {
-        setError((err as Error).message || 'Ukjent feil')
+        setError((err as Error).message || i18n.t('error.unknown'))
       }
     } finally {
       setLoading(false)

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,25 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+import no from './locales/no.json'
+import en from './locales/en.json'
+import es from './locales/es.json'
+
+const savedLang = localStorage.getItem('lang') ?? 'no'
+
+i18n.use(initReactI18next).init({
+  resources: {
+    no: { translation: no },
+    en: { translation: en },
+    es: { translation: es },
+  },
+  lng: savedLang,
+  fallbackLng: 'no',
+  interpolation: { escapeValue: false },
+})
+
+i18n.on('languageChanged', (lng) => {
+  localStorage.setItem('lang', lng)
+})
+
+export default i18n

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,50 @@
+{
+  "error": {
+    "load": "Could not load data. Please try again later.",
+    "unknown": "Unknown error"
+  },
+  "loading": "Loading data…",
+  "header": {
+    "title": "Stavanger Mobility"
+  },
+  "parking": {
+    "toggle": "Show/hide parking",
+    "label": "Parking",
+    "spots": "free spots"
+  },
+  "bikes": {
+    "toggle": "Show/hide city bikes",
+    "label": "City Bike"
+  },
+  "tab": {
+    "parking": "Parking",
+    "bikes": "City Bike"
+  },
+  "search": {
+    "parking": "Search parking…",
+    "bikes": "Search bike station…",
+    "label": "Search",
+    "clear": "Clear search"
+  },
+  "refresh": {
+    "label": "Refresh",
+    "now": "Refresh now"
+  },
+  "lastUpdated": "Last updated:",
+  "empty": {
+    "parkingSearch": "No results for \"{{query}}\"",
+    "parking": "No parking data available",
+    "bikesSearch": "No results for \"{{query}}\"",
+    "bikes": "No bike data available"
+  },
+  "bike": {
+    "available": "Available bikes",
+    "docks": "Available docks",
+    "capacity": "Capacity",
+    "inactive": "Station is not active",
+    "updated": "Updated:"
+  },
+  "data": {
+    "label": "Data:"
+  }
+}

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1,0 +1,50 @@
+{
+  "error": {
+    "load": "No se pudo cargar los datos. Inténtalo de nuevo más tarde.",
+    "unknown": "Error desconocido"
+  },
+  "loading": "Cargando datos…",
+  "header": {
+    "title": "Movilidad Stavanger"
+  },
+  "parking": {
+    "toggle": "Mostrar/ocultar aparcamiento",
+    "label": "Aparcamiento",
+    "spots": "plazas libres"
+  },
+  "bikes": {
+    "toggle": "Mostrar/ocultar bicis",
+    "label": "Bicicleta"
+  },
+  "tab": {
+    "parking": "Aparcamiento",
+    "bikes": "Bicicleta"
+  },
+  "search": {
+    "parking": "Buscar aparcamiento…",
+    "bikes": "Buscar estación…",
+    "label": "Buscar",
+    "clear": "Limpiar búsqueda"
+  },
+  "refresh": {
+    "label": "Actualizar",
+    "now": "Actualizar ahora"
+  },
+  "lastUpdated": "Última actualización:",
+  "empty": {
+    "parkingSearch": "Sin resultados para \"{{query}}\"",
+    "parking": "Sin datos de aparcamiento",
+    "bikesSearch": "Sin resultados para \"{{query}}\"",
+    "bikes": "Sin datos de bicicletas"
+  },
+  "bike": {
+    "available": "Bicis disponibles",
+    "docks": "Candados disponibles",
+    "capacity": "Capacidad",
+    "inactive": "Estación inactiva",
+    "updated": "Actualizado:"
+  },
+  "data": {
+    "label": "Datos:"
+  }
+}

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -1,0 +1,50 @@
+{
+  "error": {
+    "load": "Kunne ikke laste data. Prøv igjen senere.",
+    "unknown": "Ukjent feil"
+  },
+  "loading": "Laster data…",
+  "header": {
+    "title": "Stavanger mobilitet"
+  },
+  "parking": {
+    "toggle": "Vis/skjul parkering",
+    "label": "Parkering",
+    "spots": "ledige plasser"
+  },
+  "bikes": {
+    "toggle": "Vis/skjul bysykler",
+    "label": "Bysykkel"
+  },
+  "tab": {
+    "parking": "Parkering",
+    "bikes": "Bysykkel"
+  },
+  "search": {
+    "parking": "Søk etter parkeringsplass…",
+    "bikes": "Søk etter sykkelpunkt…",
+    "label": "Søk",
+    "clear": "Tøm søk"
+  },
+  "refresh": {
+    "label": "Oppdater",
+    "now": "Oppdater nå"
+  },
+  "lastUpdated": "Sist oppdatert:",
+  "empty": {
+    "parkingSearch": "Ingen treff på \"{{query}}\"",
+    "parking": "Ingen parkeringsdata tilgjengelig",
+    "bikesSearch": "Ingen treff på \"{{query}}\"",
+    "bikes": "Ingen sykkeldata tilgjengelig"
+  },
+  "bike": {
+    "available": "Ledige sykler",
+    "docks": "Ledige låser",
+    "capacity": "Kapasitet",
+    "inactive": "Stasjonen er ikke aktiv",
+    "updated": "Oppdatert:"
+  },
+  "data": {
+    "label": "Data:"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import './i18n'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
Extracts all hardcoded Norwegian strings into translation files and adds a compact NO | EN | ES switcher in the sidebar header. Language choice persists across page reloads via localStorage.