### PR TITLE
Add geolocation and resizable sidebar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -56,6 +56,7 @@ body {
   width: var(--eds-sidebar-width);
   flex-shrink: 0;
   height: 100%;
+  position: relative;
   background: var(--eds-bg-default);
   border-right: 1px solid var(--eds-bg-medium);
   display: flex;
@@ -491,7 +492,54 @@ body {
   animation: spin 0.8s linear infinite;
 }
 
+/* ── Sidebar resize handle ── */
+.sidebar-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -4px;
+  width: 8px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 10;
+  background: transparent;
+  transition: background 0.15s;
+}
+
+.sidebar-resize-handle:hover {
+  background: rgba(0, 112, 121, 0.2);
+}
+
+/* ── Re-center button ── */
+.recenter-btn {
+  position: absolute;
+  bottom: 32px;
+  right: 16px;
+  z-index: 1000;
+  width: 40px;
+  height: 40px;
+  background: white;
+  border: 2px solid var(--eds-bg-medium);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--eds-primary);
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.recenter-btn:hover {
+  border-color: var(--eds-primary);
+  background: var(--eds-bg-light);
+}
+
 /* ── Animations ── */
+@keyframes geo-pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.35); opacity: 0.65; }
+}
+
 @keyframes spin {
   to {
     transform: rotate(360deg);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import { Map } from './components/Map'
 import { Sidebar } from './components/Sidebar'
 import { useParking } from './hooks/useParking'
 import { useBikes } from './hooks/useBikes'
+import { useGeolocation } from './hooks/useGeolocation'
+import { useSidebarResize } from './hooks/useSidebarResize'
 import type { ParkingSpot } from './types/parking'
 import type { BikeStation } from './types/bike'
 import './App.css'
@@ -19,11 +21,19 @@ export default function App() {
   const [activeTab, setActiveTab] = useState<'parking' | 'bikes'>('parking')
   const [showParking, setShowParking] = useState(true)
   const [showBikes, setShowBikes] = useState(true)
+  const [reCenterKey, setReCenterKey] = useState(0)
 
   const parking = useParking(refreshInterval)
   const bikes = useBikes(refreshInterval)
+  const geo = useGeolocation()
+  const { width: sidebarWidth, isDragging, handleMouseDown: handleResizeMouseDown } = useSidebarResize()
 
   const anyError = parking.error || bikes.error
+
+  function handleReCenter() {
+    geo.request()
+    setReCenterKey((k) => k + 1)
+  }
 
   return (
     <div className="app">
@@ -68,9 +78,14 @@ export default function App() {
         onToggleParking={() => setShowParking((v) => !v)}
         showBikes={showBikes}
         onToggleBikes={() => setShowBikes((v) => !v)}
+        width={sidebarWidth}
+        onResizeHandleMouseDown={handleResizeMouseDown}
       />
 
-      <main className="map-container">
+      <main
+        className="map-container"
+        style={isDragging ? { pointerEvents: 'none' } : undefined}
+      >
         <Map
           spots={parking.data}
           selectedSpot={selectedSpot}
@@ -82,7 +97,24 @@ export default function App() {
           activeTab={activeTab}
           showParking={showParking}
           showBikes={showBikes}
+          userPosition={geo.position}
+          reCenterKey={reCenterKey}
         />
+
+        {geo.position && (
+          <button
+            className="recenter-btn"
+            onClick={handleReCenter}
+            aria-label={t('geo.recenter')}
+            title={t('geo.recenter')}
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="3" />
+              <path d="M12 2v3M12 19v3M2 12h3M19 12h3" />
+              <circle cx="12" cy="12" r="9" />
+            </svg>
+          </button>
+        )}
       </main>
     </div>
   )

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
-import { MapContainer, TileLayer, useMap } from 'react-leaflet'
+import { MapContainer, TileLayer, Marker, useMap } from 'react-leaflet'
+import { divIcon } from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import type { ParkingSpot } from '../types/parking'
 import type { BikeStation } from '../types/bike'
@@ -40,6 +41,56 @@ function FlyToStation({ station }: { station: BikeStation | null }) {
   return null
 }
 
+const userLocationIcon = divIcon({
+  className: '',
+  html: `
+    <div style="
+      width: 20px;
+      height: 20px;
+      background: #2563eb;
+      border-radius: 50%;
+      border: 3px solid white;
+      box-shadow: 0 0 0 2px #2563eb, 0 2px 8px rgba(0,0,0,0.4);
+      animation: geo-pulse 2s ease-in-out infinite;
+    "></div>
+  `,
+  iconSize: [20, 20],
+  iconAnchor: [10, 10],
+})
+
+function UserLocationLayer({
+  position,
+  reCenterKey,
+}: {
+  position: GeolocationCoordinates | null
+  reCenterKey: number
+}) {
+  const map = useMap()
+  const hasFlownRef = useRef(false)
+
+  // Fly to user on first fix
+  useEffect(() => {
+    if (!position || hasFlownRef.current) return
+    hasFlownRef.current = true
+    map.flyTo([position.latitude, position.longitude], 15, { duration: 1.2 })
+  }, [position, map])
+
+  // Fly on explicit re-center request
+  useEffect(() => {
+    if (reCenterKey === 0 || !position) return
+    map.flyTo([position.latitude, position.longitude], 15, { duration: 0.8 })
+  }, [reCenterKey, position, map])
+
+  if (!position) return null
+
+  return (
+    <Marker
+      position={[position.latitude, position.longitude]}
+      icon={userLocationIcon}
+    />
+  )
+}
+
 interface MapProps {
   spots: ParkingSpot[]
   selectedSpot: ParkingSpot | null
@@ -51,6 +102,8 @@ interface MapProps {
   activeTab: 'parking' | 'bikes'
   showParking: boolean
   showBikes: boolean
+  userPosition: GeolocationCoordinates | null
+  reCenterKey: number
 }
 
 export function Map({
@@ -64,6 +117,8 @@ export function Map({
   activeTab,
   showParking,
   showBikes,
+  userPosition,
+  reCenterKey,
 }: MapProps) {
   return (
     <MapContainer
@@ -110,6 +165,7 @@ export function Map({
 
       <FlyToSpot spot={selectedSpot} />
       <FlyToStation station={selectedStation} />
+      <UserLocationLayer position={userPosition} reCenterKey={reCenterKey} />
     </MapContainer>
   )
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -31,6 +31,8 @@ interface SidebarProps {
   onToggleParking: () => void
   showBikes: boolean
   onToggleBikes: () => void
+  width: number | undefined
+  onResizeHandleMouseDown: (e: React.MouseEvent) => void
 }
 
 const INTERVAL_OPTIONS = [
@@ -54,6 +56,7 @@ export function Sidebar({
   activeTab, onTabChange,
   showParking, onToggleParking,
   showBikes, onToggleBikes,
+  width, onResizeHandleMouseDown,
 }: SidebarProps) {
   const { t, i18n: i18nInstance } = useTranslation()
   const isParking = activeTab === 'parking'
@@ -70,7 +73,7 @@ export function Sidebar({
     .sort((a, b) => b.num_vehicles_available - a.num_vehicles_available)
 
   return (
-    <aside className="sidebar">
+    <aside className="sidebar" style={width !== undefined ? { width } : undefined}>
       <div className="sidebar-header">
         <div className="sidebar-title">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#007079" strokeWidth="2.5">
@@ -255,6 +258,14 @@ export function Sidebar({
         <span>{t('data.label')} </span>
         <a href="https://opencom.no" target="_blank" rel="noopener noreferrer">opencom.no</a>
       </div>
+
+      <div
+        className="sidebar-resize-handle"
+        onMouseDown={onResizeHandleMouseDown}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize sidebar"
+      />
     </aside>
   )
 }

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -1,0 +1,32 @@
+import { useState, useCallback, useEffect } from 'react'
+
+interface UseGeolocationResult {
+  position: GeolocationCoordinates | null
+  error: GeolocationPositionError | null
+  request: () => void
+}
+
+export function useGeolocation(): UseGeolocationResult {
+  const [position, setPosition] = useState<GeolocationCoordinates | null>(null)
+  const [error, setError] = useState<GeolocationPositionError | null>(null)
+
+  const request = useCallback(() => {
+    if (!navigator.geolocation) return
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setPosition(pos.coords)
+        setError(null)
+      },
+      (err) => {
+        setError(err)
+      },
+      { enableHighAccuracy: false, timeout: 8000, maximumAge: 30_000 },
+    )
+  }, [])
+
+  useEffect(() => {
+    request()
+  }, [request])
+
+  return { position, error, request }
+}

--- a/src/hooks/useSidebarResize.ts
+++ b/src/hooks/useSidebarResize.ts
@@ -1,0 +1,85 @@
+import { useState, useCallback, useEffect, useRef } from 'react'
+
+const MIN = 240
+const MAX = 480
+const DEFAULT = 300
+const STORAGE_KEY = 'sidebarWidth'
+const MOBILE_BREAKPOINT = 767
+
+function isMobile() {
+  return window.innerWidth <= MOBILE_BREAKPOINT
+}
+
+function loadWidth(): number {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      const n = Number(stored)
+      if (Number.isFinite(n)) return Math.max(MIN, Math.min(MAX, n))
+    }
+  } catch {
+    // ignore
+  }
+  return DEFAULT
+}
+
+interface UseSidebarResizeResult {
+  width: number | undefined
+  isDragging: boolean
+  handleMouseDown: (e: React.MouseEvent) => void
+}
+
+export function useSidebarResize(): UseSidebarResizeResult {
+  const [width, setWidth] = useState<number | undefined>(() =>
+    isMobile() ? undefined : loadWidth(),
+  )
+  const [isDragging, setIsDragging] = useState(false)
+  const isDraggingRef = useRef(false)
+
+  // Update width on window resize (mobile ↔ desktop switch)
+  useEffect(() => {
+    function onWindowResize() {
+      if (isMobile()) {
+        setWidth(undefined)
+      } else {
+        setWidth((prev) => prev ?? loadWidth())
+      }
+    }
+    window.addEventListener('resize', onWindowResize)
+    return () => window.removeEventListener('resize', onWindowResize)
+  }, [])
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    isDraggingRef.current = true
+    setIsDragging(true)
+    document.body.style.userSelect = 'none'
+    document.body.style.cursor = 'col-resize'
+
+    function onMouseMove(ev: MouseEvent) {
+      if (!isDraggingRef.current) return
+      const newWidth = Math.max(MIN, Math.min(MAX, ev.clientX))
+      setWidth(newWidth)
+    }
+
+    function onMouseUp(ev: MouseEvent) {
+      isDraggingRef.current = false
+      setIsDragging(false)
+      document.body.style.userSelect = ''
+      document.body.style.cursor = ''
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mouseup', onMouseUp)
+      const finalWidth = Math.max(MIN, Math.min(MAX, ev.clientX))
+      try {
+        localStorage.setItem(STORAGE_KEY, String(finalWidth))
+      } catch {
+        // ignore
+      }
+    }
+
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mouseup', onMouseUp)
+  }, [])
+
+  return { width, isDragging, handleMouseDown }
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -46,5 +46,8 @@
   },
   "data": {
     "label": "Data:"
+  },
+  "geo": {
+    "recenter": "My location"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -46,5 +46,8 @@
   },
   "data": {
     "label": "Datos:"
+  },
+  "geo": {
+    "recenter": "Mi ubicación"
   }
 }

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -46,5 +46,8 @@
   },
   "data": {
     "label": "Data:"
+  },
+  "geo": {
+    "recenter": "Min posisjon"
   }
 }


### PR DESCRIPTION
## Summary
- **Geolocation**: map auto-pans to user position on load, blue pulsing marker shows current location, re-center button (bottom-right of map) snaps back to user position
- **Resizable sidebar**: drag handle on right edge resizes between 240–480px, width persisted in localStorage, disabled on mobile
- Pointer-events suppressed on map while dragging to prevent Leaflet stealing mouse events
- New `geo.recenter` translation key added for all 3 languages (NO/EN/ES)

## Test plan
- [ ] Allow location permission → map pans to your position, blue dot appears
- [ ] Deny location permission → app loads normally with Stavanger center (silent fallback)
- [ ] Click re-center button → map flies back to user position
- [ ] Drag sidebar right edge → resizes smoothly between 240–480px
- [ ] Reload page → sidebar width is restored from localStorage
- [ ] Resize browser to mobile width → sidebar goes full-width, drag handle has no effect
- [ ] Drag sidebar into map area → resize still works (no Leaflet interference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)