### PR TITLE
Proximity sorting and live position tracking (closes #3)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -492,6 +492,44 @@ body {
   animation: spin 0.8s linear infinite;
 }
 
+/* ── Nearest-to-me sort button ── */
+.nearest-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-family: Equinor, sans-serif;
+  font-weight: 600;
+  color: #565656;
+  background: transparent;
+  border: 1.5px solid var(--eds-bg-medium);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  margin-bottom: 6px;
+}
+
+.nearest-btn:hover:not(.active) {
+  border-color: var(--eds-primary);
+  color: var(--eds-primary);
+}
+
+.nearest-btn.active {
+  background: var(--eds-primary);
+  border-color: var(--eds-primary);
+  color: #ffffff;
+}
+
+/* ── Distance label in list ── */
+.spot-distance {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--eds-primary);
+  white-space: nowrap;
+}
+
 /* ── Sidebar resize handle ── */
 .sidebar-resize-handle {
   position: absolute;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,7 @@ export default function App() {
         onToggleBikes={() => setShowBikes((v) => !v)}
         width={sidebarWidth}
         onResizeHandleMouseDown={handleResizeMouseDown}
+        userPosition={geo.position}
       />
 
       <main

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,9 +1,11 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import i18n from '../i18n'
 import type { ParkingSpot } from '../types/parking'
 import type { BikeStation } from '../types/bike'
 import { getColor } from './ParkingMarker'
 import { getBikeColor } from './BikeMarker'
+import { haversineMetres, formatDistance } from '../utils/distance'
 
 interface SidebarProps {
   // parking
@@ -33,6 +35,7 @@ interface SidebarProps {
   onToggleBikes: () => void
   width: number | undefined
   onResizeHandleMouseDown: (e: React.MouseEvent) => void
+  userPosition: GeolocationCoordinates | null
 }
 
 const INTERVAL_OPTIONS = [
@@ -57,20 +60,51 @@ export function Sidebar({
   showParking, onToggleParking,
   showBikes, onToggleBikes,
   width, onResizeHandleMouseDown,
+  userPosition,
 }: SidebarProps) {
   const { t, i18n: i18nInstance } = useTranslation()
+  const [sortByNearest, setSortByNearest] = useState(false)
+
   const isParking = activeTab === 'parking'
   const loading = isParking ? parkingLoading : bikeLoading
   const lastUpdated = isParking ? parkingLastUpdated : bikeLastUpdated
   const onRefresh = isParking ? onRefreshParking : onRefreshBikes
 
+  const canSortNearest = sortByNearest && userPosition !== null
+
   const filteredSpots = spots
     .filter((s) => s.Sted.toLowerCase().includes(searchQuery.toLowerCase()))
-    .sort((a, b) => b.Antall_ledige_plasser - a.Antall_ledige_plasser)
+    .sort((a, b) => {
+      if (canSortNearest) {
+        const distA = haversineMetres(
+          userPosition!.latitude, userPosition!.longitude,
+          parseFloat(a.Latitude), parseFloat(a.Longitude),
+        )
+        const distB = haversineMetres(
+          userPosition!.latitude, userPosition!.longitude,
+          parseFloat(b.Latitude), parseFloat(b.Longitude),
+        )
+        return distA - distB
+      }
+      return b.Antall_ledige_plasser - a.Antall_ledige_plasser
+    })
 
   const filteredStations = bikeStations
     .filter((s) => s.name.toLowerCase().includes(searchQuery.toLowerCase()))
-    .sort((a, b) => b.num_vehicles_available - a.num_vehicles_available)
+    .sort((a, b) => {
+      if (canSortNearest) {
+        const distA = haversineMetres(
+          userPosition!.latitude, userPosition!.longitude,
+          a.lat, a.lon,
+        )
+        const distB = haversineMetres(
+          userPosition!.latitude, userPosition!.longitude,
+          b.lat, b.lon,
+        )
+        return distA - distB
+      }
+      return b.num_vehicles_available - a.num_vehicles_available
+    })
 
   return (
     <aside className="sidebar" style={width !== undefined ? { width } : undefined}>
@@ -190,6 +224,21 @@ export function Sidebar({
           </button>
         </div>
 
+        {/* Nearest sort toggle — only shown when location is available */}
+        {userPosition && (
+          <button
+            className={`nearest-btn ${sortByNearest ? 'active' : ''}`}
+            onClick={() => setSortByNearest((v) => !v)}
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="3" />
+              <path d="M12 2v3M12 19v3M2 12h3M19 12h3" />
+              <circle cx="12" cy="12" r="9" />
+            </svg>
+            {sortByNearest ? t('sort.default') : t('sort.nearest')}
+          </button>
+        )}
+
         {lastUpdated && (
           <div className="last-updated">{t('lastUpdated')} {formatTime(lastUpdated)}</div>
         )}
@@ -209,6 +258,12 @@ export function Sidebar({
             {filteredSpots.map((spot) => {
               const isSelected = selectedSpot?.Sted === spot.Sted
               const color = getColor(spot.Antall_ledige_plasser)
+              const dist = canSortNearest
+                ? haversineMetres(
+                    userPosition!.latitude, userPosition!.longitude,
+                    parseFloat(spot.Latitude), parseFloat(spot.Longitude),
+                  )
+                : null
               return (
                 <button
                   key={spot.Sted}
@@ -217,7 +272,11 @@ export function Sidebar({
                 >
                   <span className="spot-indicator" style={{ background: color }} aria-hidden="true" />
                   <span className="spot-name">{spot.Sted}</span>
-                  <span className="spot-count" style={{ color }}>{spot.Antall_ledige_plasser}</span>
+                  <span className="spot-count" style={{ color }}>
+                    {dist !== null
+                      ? <span className="spot-distance">{formatDistance(dist)}</span>
+                      : spot.Antall_ledige_plasser}
+                  </span>
                 </button>
               )
             })}
@@ -234,6 +293,12 @@ export function Sidebar({
             {filteredStations.map((station) => {
               const isSelected = selectedStation?.station_id === station.station_id
               const color = getBikeColor(station)
+              const dist = canSortNearest
+                ? haversineMetres(
+                    userPosition!.latitude, userPosition!.longitude,
+                    station.lat, station.lon,
+                  )
+                : null
               return (
                 <button
                   key={station.station_id}
@@ -243,9 +308,10 @@ export function Sidebar({
                   <span className="spot-indicator bike-indicator" style={{ background: color }} aria-hidden="true" />
                   <span className="spot-name">{station.name}</span>
                   <div className="bike-counts">
-                    <span className="spot-count" style={{ color }} title={t('bike.available')}>
-                      {station.num_vehicles_available}
-                    </span>
+                    {dist !== null
+                      ? <span className="spot-distance">{formatDistance(dist)}</span>
+                      : <span className="spot-count" style={{ color }} title={t('bike.available')}>{station.num_vehicles_available}</span>
+                    }
                   </div>
                 </button>
               )

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 
 interface UseGeolocationResult {
   position: GeolocationCoordinates | null
@@ -6,13 +6,26 @@ interface UseGeolocationResult {
   request: () => void
 }
 
+const GEO_OPTIONS: PositionOptions = {
+  enableHighAccuracy: false,
+  timeout: 8000,
+  maximumAge: 30_000,
+}
+
 export function useGeolocation(): UseGeolocationResult {
   const [position, setPosition] = useState<GeolocationCoordinates | null>(null)
   const [error, setError] = useState<GeolocationPositionError | null>(null)
+  const watchIdRef = useRef<number | null>(null)
 
-  const request = useCallback(() => {
+  const startWatch = useCallback(() => {
     if (!navigator.geolocation) return
-    navigator.geolocation.getCurrentPosition(
+
+    // Clear any existing watch before starting a new one
+    if (watchIdRef.current !== null) {
+      navigator.geolocation.clearWatch(watchIdRef.current)
+    }
+
+    watchIdRef.current = navigator.geolocation.watchPosition(
       (pos) => {
         setPosition(pos.coords)
         setError(null)
@@ -20,13 +33,18 @@ export function useGeolocation(): UseGeolocationResult {
       (err) => {
         setError(err)
       },
-      { enableHighAccuracy: false, timeout: 8000, maximumAge: 30_000 },
+      GEO_OPTIONS,
     )
   }, [])
 
   useEffect(() => {
-    request()
-  }, [request])
+    startWatch()
+    return () => {
+      if (watchIdRef.current !== null) {
+        navigator.geolocation.clearWatch(watchIdRef.current)
+      }
+    }
+  }, [startWatch])
 
-  return { position, error, request }
+  return { position, error, request: startWatch }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -49,5 +49,9 @@
   },
   "geo": {
     "recenter": "My location"
+  },
+  "sort": {
+    "nearest": "Nearest to me",
+    "default": "Default order"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -49,5 +49,9 @@
   },
   "geo": {
     "recenter": "Mi ubicación"
+  },
+  "sort": {
+    "nearest": "Más cercano",
+    "default": "Orden predeterminado"
   }
 }

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -49,5 +49,9 @@
   },
   "geo": {
     "recenter": "Min posisjon"
+  },
+  "sort": {
+    "nearest": "Nærmest meg",
+    "default": "Standard rekkefølge"
   }
 }

--- a/src/utils/distance.ts
+++ b/src/utils/distance.ts
@@ -1,0 +1,22 @@
+const R = 6371000 // Earth radius in metres
+
+function toRad(deg: number): number {
+  return (deg * Math.PI) / 180
+}
+
+export function haversineMetres(
+  lat1: number, lon1: number,
+  lat2: number, lon2: number,
+): number {
+  const dLat = toRad(lat2 - lat1)
+  const dLon = toRad(lon2 - lon1)
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
+export function formatDistance(metres: number): string {
+  if (metres < 1000) return `${Math.round(metres)} m`
+  return `${(metres / 1000).toFixed(1)} km`
+}


### PR DESCRIPTION
## Summary
- **Live position tracking**: switched from `getCurrentPosition` to `watchPosition` — the blue dot and sort order now update as the user moves
- **"Nearest to me" sort**: a toggle button appears in the sidebar when location is available; tapping it sorts parking spots / bike stations by distance from the user and shows distance instead of count
- **Haversine distance utility**: `src/utils/distance.ts` — calculates metres between two coordinates and formats them as `123 m` / `1.2 km`
- Translation keys added for `sort.nearest` / `sort.default` in NO, EN, ES

## Test plan
- [ ] Allow location — blue dot appears and "Nearest to me" button shows in sidebar
- [ ] Click "Nearest to me" → list re-sorts by distance, distance label shown per item
- [ ] Click again → reverts to default sort (free spots / available bikes)
- [ ] Move location (or mock in DevTools) → sort order updates live
- [ ] Deny location → button never appears, app works normally
- [ ] Switch language → button label updates correctly

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)